### PR TITLE
Implemented new generic wrapper for Monte Carlo sweeps.

### DIFF
--- a/include/IsingModel.h
+++ b/include/IsingModel.h
@@ -8,12 +8,12 @@
 
 class IsingModel {
 public:
-    explicit IsingModel(int L = 4, double beta = 1, int seed = 5000, double J = 1); // Constructor
+    explicit IsingModel(int L = 4, double beta = 1, int seed = 5000, double J = 1);
     ~IsingModel();
 
     enum class UpdateMethod { metropolis, heatBath, wolff };
 
-    int getSpin(int i, int j, int k) const; // Accessor for spins
+    int getSpin(int i, int j, int k) const;
     std::vector<int> getNeighbors(int index) const;
     double calcEnergy() const;
     double getBeta() const;

--- a/include/IsingModel.h
+++ b/include/IsingModel.h
@@ -23,7 +23,7 @@ public:
     }
     void setSpin(int i, int j, int k, int val);
     void setBeta(double beta);
-    void monteCarloSweep(int numSweeps, UpdateMethod method, bool sequential=0);
+    void updateSweep(int numSweeps, UpdateMethod method, bool sequential=0);
 
 private:
     int L_;
@@ -33,6 +33,7 @@ private:
     std::vector<int> spins_;
     std::vector<int> NT_;
 
+    // Monte Carlo update methods
     void metropolis(int i);
     void heatBath(int i);
     int wolff();

--- a/include/IsingModel.h
+++ b/include/IsingModel.h
@@ -11,6 +11,8 @@ public:
     explicit IsingModel(int L = 4, double beta = 1, int seed = 5000, double J = 1); // Constructor
     ~IsingModel();
 
+    enum class UpdateMethod { metropolis, heatBath, wolff };
+
     int getSpin(int i, int j, int k) const; // Accessor for spins
     std::vector<int> getNeighbors(int index) const;
     double calcEnergy() const;
@@ -21,10 +23,7 @@ public:
     }
     void setSpin(int i, int j, int k, int val);
     void setBeta(double beta);
-    void metropolis(int i);
-    void heatBath(int i);
-    void wolffUpdate();
-    void monteCarloSweep(int numSweeps, bool sequential=0, void (IsingModel::*update)(int) = &IsingModel::metropolis);
+    void monteCarloSweep(int numSweeps, UpdateMethod method, bool sequential=0);
 
 private:
     int L_;
@@ -34,7 +33,9 @@ private:
     std::vector<int> spins_;
     std::vector<int> NT_;
 
-    double energy_;
+    void metropolis(int i);
+    void heatBath(int i);
+    int wolff();
 
     inline int index(int i, int j, int k) const;
     inline int mod(int i) const;

--- a/src/IsingModel.cpp
+++ b/src/IsingModel.cpp
@@ -152,22 +152,6 @@ int IsingModel::wolff() {
     return clusterSize;
 }
 
-// void IsingModel::monteCarloSweep(int numSweeps, UpdateMethod method, bool sequential) {
-//     if (method == UpdateMethod::wolff) {
-//         if (sequential) {
-//             throw std::invalid_argument("Wolff update cannot be used with sequential mode!");
-//         }
-//         else {
-//             for (int sweep = 0; sweep < numSweeps; ++sweep) {
-//                 int numFlipped = 0;
-//                 while (numFlipped < L_ *L_ *L_) {
-//                     numFlipped += wolff();
-//                 }
-//             }
-//         }
-//     }
-// }
-
 void IsingModel::monteCarloSweep(int numSweeps, UpdateMethod method, bool sequential) {
     void (IsingModel::*updateFunc)(int) = nullptr;
 
@@ -198,7 +182,7 @@ void IsingModel::monteCarloSweep(int numSweeps, UpdateMethod method, bool sequen
     if (sequential) {
         for (int sweep = 0; sweep < numSweeps; ++sweep) {
             for (int ind = 0; ind < L_ *L_ *L_; ++ind) {
-                (this->*updateFunc)(ind);  // Call the chosen update method
+                (this->*updateFunc)(ind);  
             }
         }
     }
@@ -206,47 +190,8 @@ void IsingModel::monteCarloSweep(int numSweeps, UpdateMethod method, bool sequen
         for (int sweep = 0; sweep < numSweeps; ++sweep) {
             for (int ind = 0; ind < L_ *L_ *L_; ++ind) {
                 int s = gsl_rng_uniform_int(r, L_ * L_ * L_);
-                (this->*updateFunc)(s);  // Call the chosen update method
+                (this->*updateFunc)(s);  
             }
         }
     }
 }
-
-
-    // if (sequential):
-    //     switch(method) {
-    //         case UpdateMethod::metropolis:
-    //             for (int sweep = 0; sweep < numSweeps; ++sweep) {
-    //                 for (int s = 0; s < L_ * L_ * L_; ++s) {
-    //                     method(s);
-    //                 }
-    //             }
-    //     }
-    // switch(method) {
-    //     case UpdateMethod::metropolis:
-    //         for (int sweep = 0; sweep < numSweeps; ++sweep) {
-    //             for (int s = 0; s < L_ * L_ * L_; ++s) {
-    //                 method(s);
-    //             }
-    //         }
-    //     case UpdateMethod::heatBath:
-
-    //     case UpdateMethod::wolff:
-
-    // }
-    // if (sequential) {
-    //     // Sequential update
-    //     for (int sweep = 0; sweep < numSweeps; ++sweep) {
-    //         for (int s = 0; s < L_ * L_ * L_; ++s) {
-    //             (this->*update)(s);
-    //         }
-    //     }
-    // } else {
-    //     // Random update
-    //     for (int sweep = 0; sweep < numSweeps; ++sweep) {
-    //         for (int s = 0; s < L_ * L_ * L_; ++s) {
-    //             int ind = gsl_rng_uniform_int(r, L_ * L_ * L_);
-    //             (this->*update)(ind);
-    //         }
-    //     }
-    // }

--- a/src/IsingModel.cpp
+++ b/src/IsingModel.cpp
@@ -152,7 +152,7 @@ int IsingModel::wolff() {
     return clusterSize;
 }
 
-void IsingModel::monteCarloSweep(int numSweeps, UpdateMethod method, bool sequential) {
+void IsingModel::updateSweep(int numSweeps, UpdateMethod method, bool sequential) {
     void (IsingModel::*updateFunc)(int) = nullptr;
 
     switch (method) {

--- a/src/simulatedAnnealing.cpp
+++ b/src/simulatedAnnealing.cpp
@@ -66,34 +66,32 @@ void runSimulatedAnnealing(IsingModel &model, double betaStart, double betaEnd, 
     
     // Run annealing from betaStart to betaEnd
     for (double beta = betaStart; beta <= betaEnd; beta += betaStep) {
-        // Equilibrate the system at current beta
-        model.setBeta(beta);
+        IsingModel::UpdateMethod method;
+        bool sequential;
         if (beta < 0.2) {
-            model.monteCarloSweep(equilibrationSweeps, true, &IsingModel::heatBath); // Equilibrate
+            method = IsingModel::UpdateMethod::heatBath;
+            sequential = true;
         }
         else {
-            for (int i = 0; i < 1000; ++i)
-                model.wolffUpdate();
+            method = IsingModel::UpdateMethod::wolff;
+            sequential = false;
         }
+
+        // Equilibrate the system at current beta
+        model.monteCarloSweep(equilibrationSweeps, method, sequential);
+        model.setBeta(beta);
 
         // Take measurements at current beta
         for (int i = 0; i < numMeasurements; ++i) {
             // Perform a Monte Carlo sweep to update the system
-            if (beta < 0.2) {
-                model.monteCarloSweep(numSweeps, true, &IsingModel::heatBath); // Sweep
-            }
-            else {
-                for (int i = 0; i < 500; ++i)
-                    model.wolffUpdate();
-            }
-
+            model.monteCarloSweep(numSweeps, method, sequential);
             double magnetization = model.calcMagnetization();
             m2[i] = magnetization *magnetization;
             m4[i] = m2[i] *m2[i];
         }
 
         // Calculate the Binder cumulant
-        auto [binderCumulant, binderError] = bootstrapBinderCumulant(m2, m4, r, 6000);
+        auto [binderCumulant, binderError] = bootstrapBinderCumulant(m2, m4, r, 1000);
 
         // Output the results for this beta
         outFile << beta << " " << binderCumulant << " " << binderError << std::endl;
@@ -107,18 +105,18 @@ void runSimulatedAnnealing(IsingModel &model, double betaStart, double betaEnd, 
 
 int main() {
     // Initialize Ising model
-    IsingModel model(18, 1.0, 5000, 1.0);
+    IsingModel model(10, 1.0, 5000, 1.0);
 
     // Simulated annealing parameters
     double betaStart = 0.15;
     double betaEnd = 0.25;
     double betaStep = 0.01;
-    int numSweeps = 100;
-    int equilibrationSweeps = 200;
+    int numSweeps = 200;
+    int equilibrationSweeps = 500;
     int numMeasurements = 100;
 
 
-    model.monteCarloSweep(1000, true, &IsingModel::heatBath);
+    model.monteCarloSweep(1000, IsingModel::UpdateMethod::heatBath, true);
 
     // Run the simulated annealing and measurement of Binder cumulant
     runSimulatedAnnealing(model, betaStart, betaEnd, betaStep, numSweeps, equilibrationSweeps, numMeasurements);

--- a/src/simulatedAnnealing.cpp
+++ b/src/simulatedAnnealing.cpp
@@ -78,13 +78,13 @@ void runSimulatedAnnealing(IsingModel &model, double betaStart, double betaEnd, 
         }
 
         // Equilibrate the system at current beta
-        model.monteCarloSweep(equilibrationSweeps, method, sequential);
+        model.updateSweep(equilibrationSweeps, method, sequential);
         model.setBeta(beta);
 
         // Take measurements at current beta
         for (int i = 0; i < numMeasurements; ++i) {
             // Perform a Monte Carlo sweep to update the system
-            model.monteCarloSweep(numSweeps, method, sequential);
+            model.updateSweep(numSweeps, method, sequential);
             double magnetization = model.calcMagnetization();
             m2[i] = magnetization *magnetization;
             m4[i] = m2[i] *m2[i];
@@ -105,7 +105,7 @@ void runSimulatedAnnealing(IsingModel &model, double betaStart, double betaEnd, 
 
 int main() {
     // Initialize Ising model
-    IsingModel model(10, 1.0, 5000, 1.0);
+    IsingModel model(6, 1.0, 5000, 1.0);
 
     // Simulated annealing parameters
     double betaStart = 0.15;
@@ -115,7 +115,7 @@ int main() {
     int equilibrationSweeps = 500;
     int numMeasurements = 100;
 
-    model.monteCarloSweep(1000, IsingModel::UpdateMethod::heatBath, true);
+    model.updateSweep(1000, IsingModel::UpdateMethod::heatBath, true);
 
     // Run the simulated annealing and measurement of Binder cumulant
     runSimulatedAnnealing(model, betaStart, betaEnd, betaStep, numSweeps, equilibrationSweeps, numMeasurements);

--- a/src/simulatedAnnealing.cpp
+++ b/src/simulatedAnnealing.cpp
@@ -115,7 +115,6 @@ int main() {
     int equilibrationSweeps = 500;
     int numMeasurements = 100;
 
-
     model.monteCarloSweep(1000, IsingModel::UpdateMethod::heatBath, true);
 
     // Run the simulated annealing and measurement of Binder cumulant

--- a/tests/IsingModelTest.cpp
+++ b/tests/IsingModelTest.cpp
@@ -63,7 +63,7 @@ TEST(IsingModelTest, MetropolisSweep) {
     model.setBeta(beta);
     double avg_energy = 0.0, avg_mag = 0.0;
     for (int i = 0; i < numSamples; ++i) {
-        model.monteCarloSweep(100, IsingModel::UpdateMethod::metropolis, true);
+        model.updateSweep(100, IsingModel::UpdateMethod::metropolis, true);
         avg_energy += model.calcEnergy();
         avg_mag += model.calcMagnetization();
     }
@@ -82,7 +82,7 @@ TEST(IsingModelTest, HeatBathSweep) {
     model.setBeta(beta);
     double avg_energy = 0.0, avg_mag = 0.0;
     for (int i = 0; i < numSamples; ++i) {
-        model.monteCarloSweep(100, IsingModel::UpdateMethod::heatBath, true);
+        model.updateSweep(100, IsingModel::UpdateMethod::heatBath, true);
         avg_energy += model.calcEnergy();
         avg_mag += model.calcMagnetization();
     }

--- a/tests/IsingModelTest.cpp
+++ b/tests/IsingModelTest.cpp
@@ -63,7 +63,7 @@ TEST(IsingModelTest, MetropolisSweep) {
     model.setBeta(beta);
     double avg_energy = 0.0, avg_mag = 0.0;
     for (int i = 0; i < numSamples; ++i) {
-        model.monteCarloSweep(100);
+        model.monteCarloSweep(100, IsingModel::UpdateMethod::metropolis, true);
         avg_energy += model.calcEnergy();
         avg_mag += model.calcMagnetization();
     }
@@ -82,7 +82,7 @@ TEST(IsingModelTest, HeatBathSweep) {
     model.setBeta(beta);
     double avg_energy = 0.0, avg_mag = 0.0;
     for (int i = 0; i < numSamples; ++i) {
-        model.monteCarloSweep(100, 0, &IsingModel::heatBath);
+        model.monteCarloSweep(100, IsingModel::UpdateMethod::heatBath, true);
         avg_energy += model.calcEnergy();
         avg_mag += model.calcMagnetization();
     }


### PR DESCRIPTION
I will now start working on a generic virtual base class Model.h that will be used for different types of models that will be in the future Population Annealing Monte Carlo (PAMC) code. Since these models include systems that can have updates that are not Monte Carlo, such as molecular dynamics moves, it makes sense to make the name more generic. I also encapsulated the update methods in the IsingModel class so that they are private and only accessed through the updateSweep() method along with an enumerated class that handles the update method names.